### PR TITLE
bugfix : display the translation select field in frontend

### DIFF
--- a/app/overrides/spree/shared/_main_nav_bar/locale_selector.html.erb.deface
+++ b/app/overrides/spree/shared/_main_nav_bar/locale_selector.html.erb.deface
@@ -1,4 +1,4 @@
-<!-- insert_bottom '#main-nav-bar > .navbar-right' -->
+<!-- insert_bottom '#main-nav-bar' -->
 <% if SolidusGlobalize::Config.supported_locales.many? %>
   <li id="locale-select" data-hook>
     <%= form_tag spree.set_locale_path, class: 'navbar-form' do %>


### PR DESCRIPTION
when only using `solidus_i18n`, the translation select field can be displayed in frontend, but after switching to `solidus_globalize` the translation select field is missed.

By comparing to the same partial "app/overrides/spree/shared/_main_nav_bar/locale_selector.html.erb.deface" in `solidus_i18n`: 
https://github.com/solidusio-contrib/solidus_i18n/blob/master/app/overrides/spree/shared/_main_nav_bar/locale_selector.html.erb.deface

Found that there is no `> .navbar-right`, after removing this selector, the translation select field displays well.

And about the tests, I would like to write test, but too many failures in original `solidus_globalize` master branch:

> 52 examples, 19 failures, 1 pending
