### PR TITLE
Fix .add_routes method deprecation warning

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Spree::Core::Engine.add_routes do
+Spree::Core::Engine.routes.draw do
   namespace :admin do
     get '/:resource/:resource_id/translations' => 'translations#index', as: :translations
     patch '/option_values/:id' => 'option_values#update', as: :option_type_option_value


### PR DESCRIPTION
Use .routes.draw instead
