### PR TITLE
Taxons Problems with current version of globalize

### DIFF
--- a/solidus_globalize.gemspec
+++ b/solidus_globalize.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.has_rdoc = false
 
   s.add_runtime_dependency 'friendly_id-globalize'
-  s.add_runtime_dependency 'globalize', '~> 5.0'
+  s.add_runtime_dependency 'globalize', '~> 5.1'
   s.add_runtime_dependency 'solidus_i18n', '~> 1.0'
 
   s.add_development_dependency 'byebug'


### PR DESCRIPTION
When you have globalize 5.0.1, navigation in taxonomies don’t work
correctly because the query that search the correct taxonomy serialize
an object:
`spree_taxon_translations`.`permalink` = '---
!ruby/object:ActiveRecord::StatementCache::Substitute {}\n'

But we can’t make this change today because the globalize developer didn’t plublished the 5.1.0 version. 
