### PR TITLE
Fix nil error

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,6 +1,6 @@
 module Spree
   Product.class_eval do
-    translates :name, :description, :meta_description, :meta_keywords, :slug,
+    translates :name, :description, :meta_description, :meta_keywords,
       fallbacks_for_empty_translations: true
 
     friendly_id :slug_candidates, use: [:history, :globalize]

--- a/app/models/spree/product_property_decorator.rb
+++ b/app/models/spree/product_property_decorator.rb
@@ -2,5 +2,34 @@ module Spree
   ProductProperty.class_eval do
     translates :value, fallbacks_for_empty_translations: true
     include SolidusGlobalize::Translatable
+
+    ### Fix the cooperation between solidus_globalize and spree
+    #
+    # The Problem:
+    #
+    # 1. solidus_globalize wants to translate Spree::ProductProperty#value (beside others)
+    # 2. globalize sets everything up, complains about the value column still existing
+    #      DEPRECATION WARNING: You have defined translated attributes with
+    #      names that conflict with columns on the model table. Globalize does
+    #      not support this configuration anymore, remove or rename these
+    #      columns.
+    #      Model name (table name): Spree::ProductProperty (spree_product_properties)
+    #      Attribute name(s): value
+    # 3. globalize adds "value" to Spree::ProductProperty.ignored_columns
+    #    (is considered a fix globalize/globalize#560)
+
+    # 4. A custom validator in solidus breaks because the column is not "present"
+    #    anymore (it is, but not visible to any AR introspection), but is assumed it
+    #    is.
+
+    # Here, we just remove this validation.
+    broken_validations = self._validate_callbacks.select do |c|
+      c.raw_filter.is_a?(Spree::Validations::DbMaximumLengthValidator) &&
+        c.raw_filter.options[:field] == :value
+    end
+
+    broken_validations.each do |bv|
+      self._validate_callbacks.delete(bv)
+    end
   end
 end

--- a/app/views/spree/admin/translations/_form_fields.html.erb
+++ b/app/views/spree/admin/translations/_form_fields.html.erb
@@ -20,7 +20,7 @@
           </div>
 
           <div class="panel-body">
-            <% if @resource.class.columns_hash[attr.to_s].type == :text %>
+            <% if g.object.class.columns_hash[attr.to_s].type == :text %>
               <%= g.text_area attr, class: 'form-control', rows: 4 %>
             <% else %>
               <%= g.text_field attr, class: 'form-control' %>

--- a/app/views/spree/admin/translations/_form_fields.html.erb
+++ b/app/views/spree/admin/translations/_form_fields.html.erb
@@ -1,11 +1,11 @@
 <div id="attr_fields">
   <% SolidusI18n::Config.available_locales.each do |locale| %>
     <%= f.globalize_fields_for locale.to_sym do |g| %>
-      <% @resource.class.translated_attribute_names.each_with_index do |attr, i| %>
+      <% f.object.class.translated_attribute_names.each_with_index do |attr, i| %>
         <div class="panel panel-default <%= attr %> <%= locale %>" style="display:<%= i == 0 ? 'auto' : 'none' %>;">
           <div class="panel-heading">
             <% I18n.with_locale(locale) do %>
-              <%= @resource.class.human_attribute_name(attr) %>
+              <%= f.object.class.human_attribute_name(attr) %>
 
               <div class="pull-right text-muted">
                 <small><i><%= Spree.t(:'i18n.this_file_language') %></i></small>


### PR DESCRIPTION
The Form builder provides access to the object of the form, we should use it. Additionally, the type check for the translatable field should be done on the `Translation`, not on the original model.