### PR TITLE
change 'class' to translations

### DIFF
--- a/app/views/spree/admin/translations/_form_fields.html.erb
+++ b/app/views/spree/admin/translations/_form_fields.html.erb
@@ -20,7 +20,7 @@
           </div>
 
           <div class="panel-body">
-            <% if @resource.class.columns_hash[attr.to_s].type == :text %>
+            <% if @resource.translations.columns_hash[attr.to_s].type == :text %>
               <%= g.text_area attr, class: 'form-control', rows: 4 %>
             <% else %>
               <%= g.text_field attr, class: 'form-control' %>


### PR DESCRIPTION
as the translations are no longer on the resource column_hash, it seems more sensible to check the translations columns hash instead