### PR TITLE
Fix for exception in translation view

### DIFF
--- a/app/views/spree/admin/translations/_form_fields.html.erb
+++ b/app/views/spree/admin/translations/_form_fields.html.erb
@@ -20,7 +20,7 @@
           </div>
 
           <div class="panel-body">
-            <% if @resource.class.columns_hash[attr.to_s].type == :text %>
+            <% if @resource.translations.columns_hash[attr.to_s].type == :text %>
               <%= g.text_area attr, class: 'form-control', rows: 4 %>
             <% else %>
               <%= g.text_field attr, class: 'form-control' %>


### PR DESCRIPTION
GET http://localhost:3000/admin/products/apache-baseball-jersey/translations
Resulted in:
NoMethodError in Spree::Admin::Translations#index
Showing app/views/spree/admin/translations/_form_fields.html.erb where line #23 raised:
undefined method `type' for nil:NilClass