### PR TITLE
Variant pricker search using translation

### DIFF
--- a/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
+++ b/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
@@ -1,0 +1,39 @@
+# variant autocompletion
+
+variantTemplate = HandlebarsTemplates["variants/autocomplete"]
+
+formatVariantResult = (variant) ->
+  variantTemplate(
+    variant: variant
+  )
+
+$.fn.variantAutocomplete = (searchOptions = {}) ->
+  @select2
+    placeholder: Spree.translations.variant_placeholder
+    minimumInputLength: 3
+    initSelection: (element, callback) ->
+      Spree.ajax
+        url: Spree.routes.variants_api + "/" + element.val()
+        success: callback
+    ajax:
+      url: Spree.routes.variants_api
+      datatype: "json"
+      quietMillis: 500
+      params: { "headers": { "X-Spree-Token": Spree.api_key } }
+      data: (term, page) =>
+        searchData =
+          q:
+            product_translation_name_or_sku_cont: term
+          token: Spree.api_key
+        _.extend(searchData, searchOptions)
+
+      results: (data, page) ->
+        window.variants = data["variants"]
+        results: data["variants"]
+
+    formatResult: formatVariantResult
+    formatSelection: (variant, container, escapeMarkup) ->
+      if !!variant.options_text
+        Select2.util.escapeMarkup("#{variant.name} (#{variant.options_text}")
+      else
+        Select2.util.escapeMarkup(variant.name)

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,0 +1,4 @@
+Spree::Variant.class_eval do
+  has_one :product_translation, through: :product, source: :translations
+  self.whitelisted_ransackable_associations << 'product_translation'
+end


### PR DESCRIPTION
Due to globalization while searching by product name in ransack results are getting empty for variant picker.

Passed translation table attribute to search

Override js for changing attribute