### PR TITLE
make possible searches with ransack trought product translated attributes

### DIFF
--- a/app/models/concerns/solidus_globalize/translatable.rb
+++ b/app/models/concerns/solidus_globalize/translatable.rb
@@ -3,9 +3,7 @@ module SolidusGlobalize
     extend ActiveSupport::Concern
 
     included do |klass|
-      accepts_nested_attributes_for :translations
-      klass.whitelisted_ransackable_associations ||= []
-      klass.whitelisted_ransackable_associations |= ['translations']
+      set_translation_association
     end
 
     class_methods do
@@ -30,6 +28,15 @@ module SolidusGlobalize
       def spree_base_scopes
         super.includes(:translations).references(:translations)
       end
+
+      def set_translation_association(association=:translations)
+        if self.reflect_on_association(association)
+          self.accepts_nested_attributes_for association
+          self.whitelisted_ransackable_associations ||= []
+          self.whitelisted_ransackable_associations |= [association.to_s]
+        end
+      end
+
     end
   end
 end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,0 +1,14 @@
+module Spree
+  Variant.class_eval do
+
+    def self.translated_attribute_names
+      Product.translated_attribute_names.collect{|name| :"product_#{name}" }
+    end
+
+    include SolidusGlobalize::Translatable
+
+    has_many :translations_product, through: :product,source: :translations
+    set_translation_association :translations_product
+
+  end
+end

--- a/spec/models/variant_spec.rb
+++ b/spec/models/variant_spec.rb
@@ -29,5 +29,19 @@ module Spree
       variants = described_class.includes(:product).ransack(name_cont: 'globalize').result.to_a
       expect(variants.last).to eq variant
     end
+
+    it 'fetches variant from product via translation table using ransack searches' do
+      product_relation = Product.where(name: "globalize")
+      variant_relation = described_class.joins(:product).merge(product_relation)
+      described_class.includes(:product).ransack(product_name_cont: 'globalize').result.to_a
+
+      expect(variant_relation.last).to eq variant
+
+      variants = described_class.includes(:product).ransack(product_name_cont: 'globalize').result.to_a
+      expect(variants.last).to eq variant
+    end
+
+
+
   end
 end


### PR DESCRIPTION
with this change it's possible to make a quei with ransack like this:
q[product_name_or_product_description_or_sku_cont]=mystring

every translated product attribute is included.