### PR TITLE
Use admin locales controller for updating config

### DIFF
--- a/app/controllers/spree/admin/locales_controller_decorator.rb
+++ b/app/controllers/spree/admin/locales_controller_decorator.rb
@@ -1,4 +1,4 @@
-Spree::Admin::GeneralSettingsController.class_eval do
+Spree::Admin::LocalesController.class_eval do
   before_filter :update_i18n_settings, only: :update
 
   private

--- a/app/overrides/spree/admin/locales/show/add_supported_locales.html.erb.deface
+++ b/app/overrides/spree/admin/locales/show/add_supported_locales.html.erb.deface
@@ -1,6 +1,4 @@
-<!-- insert_top '[data-hook="localization_settings_body"]'
-     sequence :after => "localization_settings"
--->
+<!-- insert_bottom '[data-hook="localization_settings_body"]' -->
 <div class="form-group">
   <label for="supported_locales_">
     <%= Spree.t(:'i18n.supported_locales') %>

--- a/app/views/spree/admin/translations/_form_fields.html.erb
+++ b/app/views/spree/admin/translations/_form_fields.html.erb
@@ -20,7 +20,7 @@
           </div>
 
           <div class="panel-body">
-            <% if @resource.class.columns_hash[attr.to_s].type == :text %>
+            <% if @resource.translations.columns_hash[attr.to_s].type == :text %>
               <%= g.text_area attr, class: 'form-control', rows: 4 %>
             <% else %>
               <%= g.text_field attr, class: 'form-control' %>

--- a/spec/features/admin/translations_spec.rb
+++ b/spec/features/admin/translations_spec.rb
@@ -226,6 +226,7 @@ RSpec.feature "Translations", :js do
       create(:store)
       SolidusI18n::Config.available_locales = [:en, :'pt-BR', :de]
       visit spree.edit_admin_general_settings_path
+      click_on "Locales"
     end
 
     scenario "adds german to supported locales" do


### PR DESCRIPTION
Solidus I18n introduced a separate admin locales controller instead of using the general settings controller. Since this gem depends on Solidus I18n we need to reflect these changes.