### PR TITLE
Remove icons from `button` and `button_link_to`

### DIFF
--- a/app/overrides/spree/admin/taxons/edit/add_translations.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/edit/add_translations.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_top 'li' -->
-<%= button_link_to Spree.t(:'i18n.translations'), spree.admin_translations_path('taxons', @taxon.id), no_text: true, icon: 'globe' %>
+<%= button_link_to Spree.t(:'i18n.translations'), spree.admin_translations_path('taxons', @taxon.id), no_text: true %>

--- a/app/views/spree/admin/translations/option_type.html.erb
+++ b/app/views/spree/admin/translations/option_type.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::OptionType.model_name.human), spree.admin_option_types_path, class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::OptionType.model_name.human), spree.admin_option_types_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/option_value.html.erb
+++ b/app/views/spree/admin/translations/option_value.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::OptionValue.model_name.human), spree.edit_admin_option_type_path(@option_value.option_type), class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::OptionValue.model_name.human), spree.edit_admin_option_type_path(@option_value.option_type), class: 'btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>
@@ -16,9 +16,9 @@
     <%= form_for [:admin, :option_type, @resource] do |f| %>
       <%= render 'form_fields', f: f %>
       <div class="form-actions" data-hook="buttons">
-        <%= button Spree.t(:update), 'update' %>
+        <%= button Spree.t(:update) %>
         <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t(:cancel), spree.edit_admin_option_type_path(@option_value.option_type), icon: 'remove' %>
+        <%= button_link_to Spree.t(:cancel), spree.edit_admin_option_type_path(@option_value.option_type) %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/product.html.erb
+++ b/app/views/spree/admin/translations/product.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/product_tabs', current: 'Translations' %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Product.model_name.human), spree.admin_products_path, class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Product.model_name.human), spree.admin_products_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/product_property.html.erb
+++ b/app/views/spree/admin/translations/product_property.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::ProductProperty.model_name.human), spree.admin_product_product_properties_path(@product_property.product), class: 'btn-primary', icon: 'icon-arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::ProductProperty.model_name.human), spree.admin_product_product_properties_path(@product_property.product), class: 'btn-primary' %>
 <% end %>
 
 <div class="row translations">
@@ -14,9 +14,9 @@
     <%= form_for [:admin, @resource.product, @resource], method: :patch do |f| %>
       <%= render 'form_fields', f: f %>
       <div class="form-actions" data-hook="buttons">
-        <%= button Spree.t(:update), 'update' %>
+        <%= button Spree.t(:update) %>
         <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t(:cancel), spree.admin_product_product_properties_path(@product_property.product), icon: 'remove' %>
+        <%= button_link_to Spree.t(:cancel), spree.admin_product_product_properties_path(@product_property.product) %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/promotion.html.erb
+++ b/app/views/spree/admin/translations/promotion.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Promotion.model_name.human), spree.admin_promotions_path, class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Promotion.model_name.human), spree.admin_promotions_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/property.html.erb
+++ b/app/views/spree/admin/translations/property.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Property.model_name.human), spree.admin_properties_path, class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Property.model_name.human), spree.admin_properties_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/shipping_method.html.erb
+++ b/app/views/spree/admin/translations/shipping_method.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-    <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::ShippingMethod.model_name.human), spree.admin_shipping_methods_path, class: 'btn-primary', :icon => 'arrow-left' %>
+    <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::ShippingMethod.model_name.human), spree.admin_shipping_methods_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/store.html.erb
+++ b/app/views/spree/admin/translations/store.html.erb
@@ -12,9 +12,9 @@
     <%= form_for [:admin, @resource], url: spree.admin_general_settings_path do |f| %>
       <%= render 'form_fields', f: f %>
       <div class="form-actions" data-hook="buttons">
-        <%= button Spree.t('actions.update'), 'refresh', 'submit', {class: 'btn-success'} %>
+        <%= button Spree.t('actions.update'), nil, 'submit', {class: 'btn-success'} %>
         <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t('actions.cancel'), spree.edit_admin_general_settings_path, icon: 'delete' %>
+        <%= button_link_to Spree.t('actions.cancel'), spree.edit_admin_general_settings_path %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/taxon.html.erb
+++ b/app/views/spree/admin/translations/taxon.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>
@@ -16,9 +16,9 @@
     <%= form_for [:admin, @resource.taxonomy, @resource], url: spree.admin_taxonomy_taxon_path(@taxon.taxonomy, @taxon.id) do |f| %>
       <%= render 'form_fields', f: f %>
       <div class="form-actions" data-hook="buttons">
-        <%= button Spree.t(:update), 'update' %>
+        <%= button Spree.t(:update) %>
         <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t(:cancel), spree.edit_admin_taxonomy_url(@taxon.taxonomy), icon: 'remove' %>
+        <%= button_link_to Spree.t(:cancel), spree.edit_admin_taxonomy_url(@taxon.taxonomy) %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/taxonomy.html.erb
+++ b/app/views/spree/admin/translations/taxonomy.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>


### PR DESCRIPTION
in order to silence `DEPRECATION WARNING: Using :icon 
option is deprecated. Icons could not be visible in 
future versions.`