### PR TITLE
Remove language icons

### DIFF
--- a/app/views/spree/admin/translations/_form_fields.html.erb
+++ b/app/views/spree/admin/translations/_form_fields.html.erb
@@ -9,12 +9,6 @@
 
               <div class="pull-right text-muted">
                 <small><i><%= Spree.t(:'i18n.this_file_language') %></i></small>
-
-                <% if locale.to_s.include?('-') %>
-                  <img src="https://www.localeapp.com/assets/flags/regions/<%= locale.to_s.split('-').last %>.png">
-                <% else %>
-                  <img src="https://www.localeapp.com/assets/flags/languages/<%= locale %>.png">
-                <% end %>
               </div>
             <% end %>
           </div>


### PR DESCRIPTION
link "https://www.localeapp.com/assets/flags/regions/:locale"
to reference icons no longer works.