### PR TITLE
Fix DbMaximumLengthValidator

### DIFF
--- a/app/models/spree/validations/db_maximum_length_validator_decorator.rb
+++ b/app/models/spree/validations/db_maximum_length_validator_decorator.rb
@@ -1,0 +1,14 @@
+module Spree
+  module Validations
+    class DbMaximumLengthValidator < ActiveModel::Validator
+      def validate(record)
+        field = @field.to_sym
+        limit = record.column_for_attribute(field).limit
+        value = record[field]
+        if value && limit && value.to_s.length > limit
+          record.errors.add(field, :too_long, count: limit)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/product_property_spec.rb
+++ b/spec/models/product_property_spec.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+module Spree
+  RSpec.describe ProductProperty, type: :model do
+    context 'when ::ignored_columns include the "value" field' do
+      before do
+        if described_class.respond_to? :ignored_columns
+          described_class.ignored_columns = ['value']
+          described_class.reset_column_information
+        end
+      end
+
+      it 'still validates the "value" field without raising an exception' do
+        expect { subject.valid? }.to_not raise_error(NoMethodError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the length validated column is now missing (because it's translated)
the #validate method raises an exception. This patch avoids the exception.

See issue https://github.com/solidusio-contrib/solidus_globalize/issues/17.

The exception can be seen when running `rake spree_sample:load` in a
Solidus app with solidus_globalize.