### PR TITLE
Various fixes for Solidus 2.0+ and Globalize 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - SOLIDUS_BRANCH=v2.0   DB=mysql
   - SOLIDUS_BRANCH=v2.1   DB=mysql
   - SOLIDUS_BRANCH=v2.2   DB=mysql
+  - SOLIDUS_BRANCH=v2.3   DB=mysql
   - SOLIDUS_BRANCH=master DB=mysql
   - SOLIDUS_BRANCH=v1.2   DB=postgres
   - SOLIDUS_BRANCH=v1.3   DB=postgres
@@ -15,6 +16,7 @@ env:
   - SOLIDUS_BRANCH=v2.0   DB=postgres
   - SOLIDUS_BRANCH=v2.1   DB=postgres
   - SOLIDUS_BRANCH=v2.2   DB=postgres
+  - SOLIDUS_BRANCH=v2.3   DB=postgres
   - SOLIDUS_BRANCH=master DB=postgres
 rvm:
   - 2.3.1

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ case branch
 when 'v1.2', 'v1.3', 'v1.4'
   gem 'globalize', '~> 5.0.0' # for Rails 4.2
 else
-  gem 'globalize', github: 'globalize/globalize' # for Rails 5
+  gem 'globalize', '~> 5.1.0.beta2' # for Rails 5
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'solidus_i18n', github: 'solidusio-contrib/solidus_i18n', branch: 'master'
 case branch
 when 'v1.2', 'v1.3', 'v1.4'
   gem 'globalize', '~> 5.0.0' # for Rails 4.2
+  gem 'rails_test_params_backport', group: :test
 else
   gem 'globalize', '~> 5.1.0.beta2' # for Rails 5
 end

--- a/app/controllers/spree/admin/resource_controller_decorator.rb
+++ b/app/controllers/spree/admin/resource_controller_decorator.rb
@@ -1,0 +1,13 @@
+module SolidusGlobalize::ResourceControllerDecorator
+  def parent
+    if parent_data.present?
+      @parent ||= parent_data[:model_class].find_by(parent_data[:find_by] => params["#{model_name}_id"])
+      instance_variable_set("@#{model_name}", @parent)
+    end
+  end
+end
+
+if SolidusSupport.solidus_gem_version >= Gem::Version.new("2.0") &&
+   SolidusSupport.solidus_gem_version < Gem::Version.new("2.3")
+  Spree::Admin::ResourceController.prepend(SolidusGlobalize::ResourceControllerDecorator)
+end

--- a/app/models/spree/validations/db_maximum_length_validator_decorator.rb
+++ b/app/models/spree/validations/db_maximum_length_validator_decorator.rb
@@ -1,0 +1,14 @@
+module Spree
+  module Validations
+    class DbMaximumLengthValidator < ActiveModel::Validator
+      def validate(record)
+        field = @field.to_sym
+        limit = record.column_for_attribute(field).limit
+        value = record[field]
+        if value && limit && value.to_s.length > limit
+          record.errors.add(field, :too_long, count: limit)
+        end
+      end
+    end
+  end
+end

--- a/app/views/spree/admin/translations/_form_fields.html.erb
+++ b/app/views/spree/admin/translations/_form_fields.html.erb
@@ -20,7 +20,7 @@
           </div>
 
           <div class="panel-body">
-            <% if @resource.class.columns_hash[attr.to_s].type == :text %>
+            <% if @resource.class.translation_class.columns_hash[attr.to_s].type == :text %>
               <%= g.text_area attr, class: 'form-control', rows: 4 %>
             <% else %>
               <%= g.text_field attr, class: 'form-control' %>

--- a/db/migrate/20130419041407_add_translations_to_main_models.rb
+++ b/db/migrate/20130419041407_add_translations_to_main_models.rb
@@ -1,4 +1,4 @@
-class AddTranslationsToMainModels < ActiveRecord::Migration
+class AddTranslationsToMainModels < SolidusSupport::Migration[4.2]
   def up
     unless table_exists?(:spree_product_translations)
       params = { name: :string, description: :text, meta_description: :string,

--- a/db/migrate/20130518224827_add_translations_to_product_permalink.rb
+++ b/db/migrate/20130518224827_add_translations_to_product_permalink.rb
@@ -1,4 +1,4 @@
-class AddTranslationsToProductPermalink < ActiveRecord::Migration
+class AddTranslationsToProductPermalink < SolidusSupport::Migration[4.2]
   def up
     if column_exists?(:spree_products, :permalink)
       fields = { permalink: :string }

--- a/db/migrate/20131009091000_add_translations_to_option_value.rb
+++ b/db/migrate/20131009091000_add_translations_to_option_value.rb
@@ -1,4 +1,4 @@
-class AddTranslationsToOptionValue < ActiveRecord::Migration
+class AddTranslationsToOptionValue < SolidusSupport::Migration[4.2]
   def up
     unless table_exists?(:spree_option_value_translations)
       params = { name: :string, presentation: :string }

--- a/db/migrate/20140206202524_rename_activator_translations_to_promotion_translations.rb
+++ b/db/migrate/20140206202524_rename_activator_translations_to_promotion_translations.rb
@@ -1,4 +1,4 @@
-class RenameActivatorTranslationsToPromotionTranslations < ActiveRecord::Migration
+class RenameActivatorTranslationsToPromotionTranslations < SolidusSupport::Migration[4.2]
   def change
     if table_exists? 'spree_activator_translations'
       rename_table :spree_activator_translations, :spree_promotion_translations

--- a/db/migrate/20140219130603_update_spree_product_translations.rb
+++ b/db/migrate/20140219130603_update_spree_product_translations.rb
@@ -1,4 +1,4 @@
-class UpdateSpreeProductTranslations < ActiveRecord::Migration
+class UpdateSpreeProductTranslations < SolidusSupport::Migration[4.2]
   def change
     if column_exists?(:spree_product_translations, :permalink)
       rename_column :spree_product_translations, :permalink, :slug

--- a/db/migrate/20141112121313_add_translations_to_product_properties.rb
+++ b/db/migrate/20141112121313_add_translations_to_product_properties.rb
@@ -1,4 +1,4 @@
-class AddTranslationsToProductProperties < ActiveRecord::Migration
+class AddTranslationsToProductProperties < SolidusSupport::Migration[4.2]
   def up
     unless table_exists?(:spree_product_property_translations)
       params = { value: :string }

--- a/db/migrate/20150217095648_remove_null_constraints_from_spree_tables.rb
+++ b/db/migrate/20150217095648_remove_null_constraints_from_spree_tables.rb
@@ -1,4 +1,4 @@
-class RemoveNullConstraintsFromSpreeTables < ActiveRecord::Migration
+class RemoveNullConstraintsFromSpreeTables < SolidusSupport::Migration[4.2]
   def up
     change_column :spree_properties, :presentation, :string, null: true
     change_column :spree_taxonomies, :name,         :string, null: true

--- a/db/migrate/20150224152415_add_deleted_at_to_translation_tables.rb
+++ b/db/migrate/20150224152415_add_deleted_at_to_translation_tables.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToTranslationTables < ActiveRecord::Migration
+class AddDeletedAtToTranslationTables < SolidusSupport::Migration[4.2]
   def change
     unless column_exists?(:spree_product_translations, :deleted_at)
       add_column :spree_product_translations, :deleted_at, :datetime

--- a/db/migrate/20150323210949_add_translations_to_store.rb
+++ b/db/migrate/20150323210949_add_translations_to_store.rb
@@ -1,4 +1,4 @@
-class AddTranslationsToStore < ActiveRecord::Migration
+class AddTranslationsToStore < SolidusSupport::Migration[4.2]
   def up
     unless table_exists?(:spree_store_translations)
       params = { name: :string, meta_description: :text, meta_keywords: :text, seo_title: :string }

--- a/db/migrate/20150429121917_add_translations_to_shipping_method.rb
+++ b/db/migrate/20150429121917_add_translations_to_shipping_method.rb
@@ -1,4 +1,4 @@
-class AddTranslationsToShippingMethod < ActiveRecord::Migration
+class AddTranslationsToShippingMethod < SolidusSupport::Migration[4.2]
   def up
     params = { name: :string }
     Spree::ShippingMethod.create_translation_table!(params, { migrate_data: true })

--- a/lib/solidus_globalize.rb
+++ b/lib/solidus_globalize.rb
@@ -1,6 +1,7 @@
 require 'rails'
 require 'sass/rails'
 require 'solidus_i18n'
+require 'solidus_support'
 require 'solidus_globalize/engine'
 require 'solidus_globalize/version'
 require 'coffee_script'

--- a/solidus_globalize.gemspec
+++ b/solidus_globalize.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'friendly_id-globalize'
   s.add_runtime_dependency 'globalize', '~> 5.0'
   s.add_runtime_dependency 'solidus_i18n', '~> 1.0'
+  s.add_runtime_dependency 'solidus_support'
 
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'capybara', '~> 2.4'

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -8,7 +8,7 @@ module Spree
 
     context "visit non translated product page via permalink on url" do
       it "displays pages successfully" do
-        spree_get :show, id: product.slug, locale: 'pt-BR'
+        get :show, params: { id: product.slug, locale: 'pt-BR' }
         expect(response).to be_success
       end
     end

--- a/spec/models/product_property_spec.rb
+++ b/spec/models/product_property_spec.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+module Spree
+  RSpec.describe ProductProperty, type: :model do
+    context 'when ::ignored_columns include the "value" field' do
+      before do
+        if described_class.respond_to? :ignored_columns
+          described_class.ignored_columns = ['value']
+          described_class.reset_column_information
+        end
+      end
+
+      it 'still validates the "value" field without raising an exception' do
+        expect { subject.valid? }.to_not raise_error(NoMethodError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes the build for Solidus 2.0+, currently broken because Globalize 5.1 removes the translated columns from the model table.

Includes code from #50 and #53