### PR TITLE
concern for DbMaximumLengthValidator to override the validation method

### DIFF
--- a/app/models/concerns/solidus_globalize/db_maximum_length_validator.rb
+++ b/app/models/concerns/solidus_globalize/db_maximum_length_validator.rb
@@ -1,0 +1,19 @@
+module SolidusGlobalize
+  module DbMaximumLengthValidator
+    extend ActiveSupport::Concern
+
+    included do
+
+      def validate(record)
+        field = @field.to_sym
+        limit = record.column_for_attribute(field).limit
+        value = record[field]
+        if value && limit && value.to_s.length > limit
+          record.errors.add(field, :too_long, count: limit)
+        end
+      end
+
+    end
+
+  end
+end

--- a/app/models/spree/validations/db_maximum_length_validator_decorator.rb
+++ b/app/models/spree/validations/db_maximum_length_validator_decorator.rb
@@ -1,14 +1,1 @@
-module Spree
-  module Validations
-    class DbMaximumLengthValidator < ActiveModel::Validator
-      def validate(record)
-        field = @field.to_sym
-        limit = record.column_for_attribute(field).limit
-        value = record[field]
-        if value && limit && value.to_s.length > limit
-          record.errors.add(field, :too_long, count: limit)
-        end
-      end
-    end
-  end
-end
+Spree::Validations::DbMaximumLengthValidator.include(SolidusGlobalize::DbMaximumLengthValidator)


### PR DESCRIPTION
the solidus validator class make an override of the initialization and initialize the @field.
if we reopen the  class and hinerit from ActiveRecord::Validator we lose the initialization, and so the @field variable