### PR TITLE
Restore variant search spec

### DIFF
--- a/spec/models/variant_spec.rb
+++ b/spec/models/variant_spec.rb
@@ -19,16 +19,14 @@ module Spree
       )
     end
 
-    # this test is invalid, should be removed or changed
-    #  see https://github.com/spree-contrib/spree_globalize/commit/87802a97c8ee82f5444243467faf2a8faa8236f6#commitcomment-12963401
-    xit 'fetches variant from product via translation table' do
+    it 'fetches variant from product via translation table using ransack searches' do
       product_relation = Product.where(name: "globalize")
       variant_relation = described_class.joins(:product).merge(product_relation)
-      described_class.includes(:product).ransack(name_cont: 'globalize').result.to_a
+      described_class.includes(:product).ransack(translations_product_name_cont: 'globalize').result.to_a
 
       expect(variant_relation.last).to eq variant
 
-      variants = described_class.includes(:product).ransack(name_cont: 'globalize').result.to_a
+      variants = described_class.includes(:product).ransack(translations_product_name_cont: 'globalize').result.to_a
       expect(variants.last).to eq variant
     end
   end


### PR DESCRIPTION
It was just using the wrong reference for ransack.