### PR TITLE
Allow set custom permission to allow/deny translations access

### DIFF
--- a/app/controllers/spree/admin/translations_controller.rb
+++ b/app/controllers/spree/admin/translations_controller.rb
@@ -28,6 +28,8 @@ module Spree
       def klass
         @klass ||= "Spree::#{params[:resource].classify}".constantize
       end
+      # alias to model_class in order to fallback on the resource for the authorizations
+      alias_method :model_class, :klass
 
       def resource
         @resource ||= if slugged_models.include? klass.class_name

--- a/spec/controllers/spree/admin/translations_controller_spec.rb
+++ b/spec/controllers/spree/admin/translations_controller_spec.rb
@@ -1,0 +1,38 @@
+module Spree
+  RSpec.describe Admin::TranslationsController, type: :controller do
+    let!(:product) { create(:product) }
+
+    context 'as a full admin' do
+      stub_authorization!
+
+      it 'displays page successfully' do
+        get :index, params: { resource: 'products', resource_id: product.slug }
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'as a limited admin' do
+      context 'when I cannot manage products' do
+        stub_authorization! do |_|
+          cannot :manage, Spree::Product
+        end
+
+        it 'redirect to authorization failure' do
+          get :index, params: { resource: 'products', resource_id: product.slug }
+          expect(response).to redirect_to '/unauthorized'
+        end
+      end
+
+      context 'when I can manage products' do
+        stub_authorization! do |_|
+          can :manage, Spree::Product
+        end
+
+        it 'displays page successfully' do
+          get :index, params: { resource: 'products', resource_id: product.slug }
+          expect(response).to have_http_status(:success)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Based on #51 by @oeN. 

The `backend/app/controllers/spree/admin/base_controller.rb` uses the model_class to authorize an admin for a given action.

To allow a user with a custom PermissionSet to access the translations
an `alias_method :model_class, :klass` is enough.

In this way if a PermissionSet say:

```ruby
class CustomPermission < Spree::PermissionSets::Base
  def activate!
    can :manage, Spree::Product
  end
end
```

the user will be able to :manage the `Spree::Product::Translation` too.