### PR TITLE
Remove solidus deprecations

### DIFF
--- a/app/overrides/spree/admin/locales/show/add_supported_locales.html.erb.deface
+++ b/app/overrides/spree/admin/locales/show/add_supported_locales.html.erb.deface
@@ -1,10 +1,10 @@
 <!-- insert_bottom '[data-hook="localization_settings_body"]' -->
 <div class="form-group">
   <label for="supported_locales_">
-    <%= Spree.t(:'i18n.supported_locales') %>
+    <%= I18n.t(:'spree.i18n.supported_locales') %>
   </label>
   <%= select_supported_locales %>
   <p class="help-block">
-    <%= Spree.t(:'globalize.locales_displayed_on_translation_forms') %>
+    <%= I18n.t(:'spree.globalize.locales_displayed_on_translation_forms') %>
   </p>
 </div>

--- a/app/overrides/spree/admin/locales/show/add_supported_locales.html.erb.deface
+++ b/app/overrides/spree/admin/locales/show/add_supported_locales.html.erb.deface
@@ -1,10 +1,10 @@
 <!-- insert_bottom '[data-hook="localization_settings_body"]' -->
 <div class="form-group">
   <label for="supported_locales_">
-    <%= I18n.t(:'spree.i18n.supported_locales') %>
+    <%= t(:'spree.i18n.supported_locales') %>
   </label>
   <%= select_supported_locales %>
   <p class="help-block">
-    <%= I18n.t(:'spree.globalize.locales_displayed_on_translation_forms') %>
+    <%= t(:'spree.globalize.locales_displayed_on_translation_forms') %>
   </p>
 </div>

--- a/app/overrides/spree/admin/option_types/_option_value_fields/add_translation.html.erb.deface
+++ b/app/overrides/spree/admin/option_types/_option_value_fields/add_translation.html.erb.deface
@@ -1,4 +1,4 @@
 <!-- insert_bottom 'td.actions' -->
 <% if f.object.persisted? %>
-  <%= link_to_with_icon 'globe', nil, spree.admin_translations_path('option_values', f.object.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>
+  <%= link_to_with_icon 'globe', nil, spree.admin_translations_path('option_values', f.object.id), title: t(:'spree.i18n.translations'), no_text: true %>
 <% end %>

--- a/app/overrides/spree/admin/option_types/_option_value_fields/add_translation.html.erb.deface
+++ b/app/overrides/spree/admin/option_types/_option_value_fields/add_translation.html.erb.deface
@@ -1,4 +1,4 @@
 <!-- insert_bottom 'td.actions' -->
 <% if f.object.persisted? %>
-  <%= link_to_with_icon 'globe', nil, spree.admin_translations_path('option_values', f.object.id), title: Spree.t(:'i18n.translations'), no_text: true %>
+  <%= link_to_with_icon 'globe', nil, spree.admin_translations_path('option_values', f.object.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>
 <% end %>

--- a/app/overrides/spree/admin/option_types/index/add_translation.html.erb.deface
+++ b/app/overrides/spree/admin/option_types/index/add_translation.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom 'td.actions' -->
-<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('option_types', option_type.id), title: Spree.t(:'i18n.translations'), no_text: true %>
+<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('option_types', option_type.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>

--- a/app/overrides/spree/admin/option_types/index/add_translation.html.erb.deface
+++ b/app/overrides/spree/admin/option_types/index/add_translation.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom 'td.actions' -->
-<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('option_types', option_type.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>
+<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('option_types', option_type.id), title: t(:'spree.i18n.translations'), no_text: true %>

--- a/app/overrides/spree/admin/product_properties/_product_property_fields/add_translation.html.erb.deface
+++ b/app/overrides/spree/admin/product_properties/_product_property_fields/add_translation.html.erb.deface
@@ -1,4 +1,4 @@
 <!-- insert_bottom 'td.actions' -->
 <% if f.object.persisted? %>
-  <%= link_to_with_icon 'globe', nil, spree.admin_translations_path('product_property', f.object.id), title: Spree.t(:'i18n.translations'), no_text: true %>
+  <%= link_to_with_icon 'globe', nil, spree.admin_translations_path('product_property', f.object.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>
 <% end %>

--- a/app/overrides/spree/admin/product_properties/_product_property_fields/add_translation.html.erb.deface
+++ b/app/overrides/spree/admin/product_properties/_product_property_fields/add_translation.html.erb.deface
@@ -1,4 +1,4 @@
 <!-- insert_bottom 'td.actions' -->
 <% if f.object.persisted? %>
-  <%= link_to_with_icon 'globe', nil, spree.admin_translations_path('product_property', f.object.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>
+  <%= link_to_with_icon 'globe', nil, spree.admin_translations_path('product_property', f.object.id), title: t(:'spree.i18n.translations'), no_text: true %>
 <% end %>

--- a/app/overrides/spree/admin/promotions/index/add_translation_link.html.erb.deface
+++ b/app/overrides/spree/admin/promotions/index/add_translation_link.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom 'td.actions' -->
-<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('promotions', promotion.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>
+<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('promotions', promotion.id), title: t(:'spree.i18n.translations'), no_text: true %>

--- a/app/overrides/spree/admin/promotions/index/add_translation_link.html.erb.deface
+++ b/app/overrides/spree/admin/promotions/index/add_translation_link.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom 'td.actions' -->
-<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('promotions', promotion.id), title: Spree.t(:'i18n.translations'), no_text: true %>
+<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('promotions', promotion.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>

--- a/app/overrides/spree/admin/properties/index/add_translation.html.erb.deface
+++ b/app/overrides/spree/admin/properties/index/add_translation.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom 'td.actions' -->
-<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('properties', property.id), title: Spree.t(:'i18n.translations'), no_text: true %>
+<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('properties', property.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>

--- a/app/overrides/spree/admin/properties/index/add_translation.html.erb.deface
+++ b/app/overrides/spree/admin/properties/index/add_translation.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom 'td.actions' -->
-<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('properties', property.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>
+<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('properties', property.id), title: t(:'spree.i18n.translations'), no_text: true %>

--- a/app/overrides/spree/admin/shared/_product_tabs/add_translations.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_translations.html.erb.deface
@@ -1,4 +1,4 @@
 <!-- insert_bottom "[data-hook='admin_product_tabs']" -->
 <li<%== ' class="active"' if current == 'Translations' %>>
-  <%= link_to Spree.t(:'i18n.translations'), spree.admin_translations_url('products', @product.slug) %>
+  <%= link_to I18n.t(:'spree.i18n.translations'), spree.admin_translations_url('products', @product.slug) %>
 </li>

--- a/app/overrides/spree/admin/shared/_product_tabs/add_translations.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_translations.html.erb.deface
@@ -1,4 +1,4 @@
 <!-- insert_bottom "[data-hook='admin_product_tabs']" -->
 <li<%== ' class="active"' if current == 'Translations' %>>
-  <%= link_to I18n.t(:'spree.i18n.translations'), spree.admin_translations_url('products', @product.slug) %>
+  <%= link_to t(:'spree.i18n.translations'), spree.admin_translations_url('products', @product.slug) %>
 </li>

--- a/app/overrides/spree/admin/shared/_product_tabs/add_translations.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_translations.html.erb.deface
@@ -1,4 +1,4 @@
 <!-- insert_bottom "[data-hook='admin_product_tabs']" -->
 <li<%== ' class="active"' if current == 'Translations' %>>
-  <%= link_to_with_icon 'globe', Spree.t(:'i18n.translations'), spree.admin_translations_url('products', @product.slug), title: Spree.t(:'i18n.translations') %>
+  <%= link_to Spree.t(:'i18n.translations'), spree.admin_translations_url('products', @product.slug) %>
 </li>

--- a/app/overrides/spree/admin/shared/_translations/translation.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_translations/translation.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom 'script' -->
-$.extend(Spree.translations, { translations: "<%= strip_tags(I18n.t(:'spree.i18n.translations')) %>" })
+$.extend(Spree.translations, { translations: "<%= strip_tags(t(:'spree.i18n.translations')) %>" })

--- a/app/overrides/spree/admin/shared/_translations/translation.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_translations/translation.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom 'script' -->
-$.extend(Spree.translations, { translations: "<%= strip_tags(Spree.t(:'i18n.translations')) %>" })
+$.extend(Spree.translations, { translations: "<%= strip_tags(I18n.t(:'spree.i18n.translations')) %>" })

--- a/app/overrides/spree/admin/shared/sub_menu/_configuration/store_translations.html.erb.deface
+++ b/app/overrides/spree/admin/shared/sub_menu/_configuration/store_translations.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom "[data-hook='admin_configurations_sidebar_menu']" -->
-<%= configurations_sidebar_menu_item I18n.t(:'spree.globalize.store_translations'), spree.admin_translations_path('stores', current_store.id)  if can? :manage, Spree::Store %>
+<%= configurations_sidebar_menu_item t(:'spree.globalize.store_translations'), spree.admin_translations_path('stores', current_store.id)  if can? :manage, Spree::Store %>

--- a/app/overrides/spree/admin/shared/sub_menu/_configuration/store_translations.html.erb.deface
+++ b/app/overrides/spree/admin/shared/sub_menu/_configuration/store_translations.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom "[data-hook='admin_configurations_sidebar_menu']" -->
-<%= configurations_sidebar_menu_item Spree.t(:'globalize.store_translations'), spree.admin_translations_path('stores', current_store.id)  if can? :manage, Spree::Store %>
+<%= configurations_sidebar_menu_item I18n.t(:'spree.globalize.store_translations'), spree.admin_translations_path('stores', current_store.id)  if can? :manage, Spree::Store %>

--- a/app/overrides/spree/admin/shipping_methods/index/add_translation.html.erb.deface
+++ b/app/overrides/spree/admin/shipping_methods/index/add_translation.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom 'td.actions' -->
-<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('shipping_methods', shipping_method.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>
+<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('shipping_methods', shipping_method.id), title: t(:'spree.i18n.translations'), no_text: true %>

--- a/app/overrides/spree/admin/shipping_methods/index/add_translation.html.erb.deface
+++ b/app/overrides/spree/admin/shipping_methods/index/add_translation.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom 'td.actions' -->
-<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('shipping_methods', shipping_method.id), title: Spree.t(:'i18n.translations'), no_text: true %>
+<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('shipping_methods', shipping_method.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>

--- a/app/overrides/spree/admin/taxonomies/_list/add_translations.html.erb.deface
+++ b/app/overrides/spree/admin/taxonomies/_list/add_translations.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom 'td.actions' -->
-<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('taxonomies', taxonomy.id), title: Spree.t(:'i18n.translations'), no_text: true %>
+<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('taxonomies', taxonomy.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>

--- a/app/overrides/spree/admin/taxonomies/_list/add_translations.html.erb.deface
+++ b/app/overrides/spree/admin/taxonomies/_list/add_translations.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_bottom 'td.actions' -->
-<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('taxonomies', taxonomy.id), title: I18n.t(:'spree.i18n.translations'), no_text: true %>
+<%= link_to_with_icon 'globe', nil, spree.admin_translations_path('taxonomies', taxonomy.id), title: t(:'spree.i18n.translations'), no_text: true %>

--- a/app/overrides/spree/admin/taxons/edit/add_translations.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/edit/add_translations.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_top 'li' -->
-<%= button_link_to Spree.t(:'i18n.translations'), spree.admin_translations_path('taxons', @taxon.id), no_text: true, icon: 'globe' %>
+<%= button_link_to Spree.t(:'i18n.translations'), spree.admin_translations_path('taxons', @taxon.id), no_text: true %>

--- a/app/overrides/spree/admin/taxons/edit/add_translations.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/edit/add_translations.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_top 'li' -->
-<%= button_link_to Spree.t(:'i18n.translations'), spree.admin_translations_path('taxons', @taxon.id), no_text: true %>
+<%= button_link_to I18n.t(:'spree.i18n.translations'), spree.admin_translations_path('taxons', @taxon.id), no_text: true %>

--- a/app/overrides/spree/admin/taxons/edit/add_translations.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/edit/add_translations.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_top 'li' -->
-<%= button_link_to I18n.t(:'spree.i18n.translations'), spree.admin_translations_path('taxons', @taxon.id), no_text: true %>
+<%= link_to I18n.t(:'spree.i18n.translations'), spree.admin_translations_path('taxons', @taxon.id), class: 'btn btn-default' %>

--- a/app/overrides/spree/admin/taxons/edit/add_translations.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/edit/add_translations.html.erb.deface
@@ -1,2 +1,2 @@
 <!-- insert_top 'li' -->
-<%= link_to I18n.t(:'spree.i18n.translations'), spree.admin_translations_path('taxons', @taxon.id), class: 'btn btn-default' %>
+<%= link_to t(:'spree.i18n.translations'), spree.admin_translations_path('taxons', @taxon.id), class: 'btn btn-default' %>

--- a/app/overrides/spree/shared/_main_nav_bar/locale_selector.html.erb.deface
+++ b/app/overrides/spree/shared/_main_nav_bar/locale_selector.html.erb.deface
@@ -4,7 +4,7 @@
     <%= form_tag spree.set_locale_path, no_text: truenavbar-form' do %>
       <div class="form-group">
         <label for="switch_to_locale" class="sr-only">
-          <%= I18n.t(:'spree.i18n.language') %>
+          <%= t(:'spree.i18n.language') %>
         </label>
         <%= select_tag(:switch_to_locale, options_for_select(supported_locales_options, I18n.locale), no_text: trueform-control') %>
         <noscript><%= submit_tag %></noscript>

--- a/app/overrides/spree/shared/_main_nav_bar/locale_selector.html.erb.deface
+++ b/app/overrides/spree/shared/_main_nav_bar/locale_selector.html.erb.deface
@@ -4,7 +4,7 @@
     <%= form_tag spree.set_locale_path, no_text: truenavbar-form' do %>
       <div class="form-group">
         <label for="switch_to_locale" class="sr-only">
-          <%= Spree.t(:'i18n.language') %>
+          <%= I18n.t(:'spree.i18n.language') %>
         </label>
         <%= select_tag(:switch_to_locale, options_for_select(supported_locales_options, I18n.locale), no_text: trueform-control') %>
         <noscript><%= submit_tag %></noscript>

--- a/app/views/spree/admin/translations/_fields.html.erb
+++ b/app/views/spree/admin/translations/_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default fields">
   <div class="panel-heading">
-    <%= Spree.t(:'i18n.fields') %>
+    <%= I18n.t(:'spree.i18n.fields') %>
   </div>
   <div class="list-group" id="attr_list">
     <% @resource.class.translated_attribute_names.each_with_index do |attr, i| %>

--- a/app/views/spree/admin/translations/_fields.html.erb
+++ b/app/views/spree/admin/translations/_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default fields">
   <div class="panel-heading">
-    <%= I18n.t(:'spree.i18n.fields') %>
+    <%= t(:'spree.i18n.fields') %>
   </div>
   <div class="list-group" id="attr_list">
     <% @resource.class.translated_attribute_names.each_with_index do |attr, i| %>

--- a/app/views/spree/admin/translations/_form_fields.html.erb
+++ b/app/views/spree/admin/translations/_form_fields.html.erb
@@ -8,7 +8,7 @@
               <%= @resource.class.human_attribute_name(attr) %>
 
               <div class="pull-right text-muted">
-                <small><i><%= Spree.t(:'i18n.this_file_language') %></i></small>
+                <small><i><%= I18n.t(:'spree.i18n.this_file_language') %></i></small>
               </div>
             <% end %>
           </div>
@@ -26,7 +26,7 @@
   <% end %>
 
   <p class="no-translations" style="display: none">
-    <%= Spree.t(:'globalize.no_translations_for_criteria') %>
+    <%= I18n.t(:'spree.globalize.no_translations_for_criteria') %>
   </p>
 </div>
 

--- a/app/views/spree/admin/translations/_form_fields.html.erb
+++ b/app/views/spree/admin/translations/_form_fields.html.erb
@@ -8,7 +8,7 @@
               <%= @resource.class.human_attribute_name(attr) %>
 
               <div class="pull-right text-muted">
-                <small><i><%= I18n.t(:'spree.i18n.this_file_language') %></i></small>
+                <small><i><%= t(:'spree.i18n.this_file_language') %></i></small>
               </div>
             <% end %>
           </div>
@@ -26,7 +26,7 @@
   <% end %>
 
   <p class="no-translations" style="display: none">
-    <%= I18n.t(:'spree.globalize.no_translations_for_criteria') %>
+    <%= t(:'spree.globalize.no_translations_for_criteria') %>
   </p>
 </div>
 

--- a/app/views/spree/admin/translations/_settings.html.erb
+++ b/app/views/spree/admin/translations/_settings.html.erb
@@ -2,11 +2,11 @@
   <div class="row no-padding-bottom">
     <div class="col-md-4">
       <div class="form-group no-margin-bottom">
-        <label><%= I18n.t(:'spree.show') %></label>
+        <label><%= t(:'spree.show') %></label>
         <select class="form-control" name="show-only">
-          <option value="all"><%= I18n.t(:'spree.all') %></option>
-          <option value="incomplete"><%= I18n.t(:'spree.i18n.only_incomplete') %></option>
-          <option value="complete"><%= I18n.t(:'spree.i18n.only_complete') %></option>
+          <option value="all"><%= t(:'spree.all') %></option>
+          <option value="incomplete"><%= t(:'spree.i18n.only_incomplete') %></option>
+          <option value="complete"><%= t(:'spree.i18n.only_complete') %></option>
         </select>
       </div>
     </div>
@@ -14,7 +14,7 @@
     <div class="col-md-8">
       <div class="form-group no-margin-bottom">
         <label>
-          <%= I18n.t(:'spree.i18n.select_locale') %>
+          <%= t(:'spree.i18n.select_locale') %>
           <%= select_available_locales_fields %>
         </label>
       </div>

--- a/app/views/spree/admin/translations/_settings.html.erb
+++ b/app/views/spree/admin/translations/_settings.html.erb
@@ -2,11 +2,11 @@
   <div class="row no-padding-bottom">
     <div class="col-md-4">
       <div class="form-group no-margin-bottom">
-        <label><%= Spree.t(:show) %></label>
+        <label><%= I18n.t(:'spree.show') %></label>
         <select class="form-control" name="show-only">
-          <option value="all"><%= Spree.t(:all) %></option>
-          <option value="incomplete"><%= Spree.t(:'i18n.only_incomplete') %></option>
-          <option value="complete"><%= Spree.t(:'i18n.only_complete') %></option>
+          <option value="all"><%= I18n.t(:'spree.all') %></option>
+          <option value="incomplete"><%= I18n.t(:'spree.i18n.only_incomplete') %></option>
+          <option value="complete"><%= I18n.t(:'spree.i18n.only_complete') %></option>
         </select>
       </div>
     </div>
@@ -14,7 +14,7 @@
     <div class="col-md-8">
       <div class="form-group no-margin-bottom">
         <label>
-          <%= Spree.t(:'i18n.select_locale') %>
+          <%= I18n.t(:'spree.i18n.select_locale') %>
           <%= select_available_locales_fields %>
         </label>
       </div>

--- a/app/views/spree/admin/translations/option_type.html.erb
+++ b/app/views/spree/admin/translations/option_type.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::OptionType.model_name.human), spree.admin_option_types_path, class: 'btn-primary' %>
+  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::OptionType.model_name.human), spree.admin_option_types_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/option_type.html.erb
+++ b/app/views/spree/admin/translations/option_type.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::OptionType.model_name.human) %> <span class="green">"<%= @option_type.name %>"</span>
+  <%= I18n.t(:'spree.editing_resource', resource: Spree::OptionType.model_name.human) %> <span class="green">"<%= @option_type.name %>"</span>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::OptionType.model_name.human), spree.admin_option_types_path, class: 'btn-primary' %>
+  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::OptionType.model_name.human), spree.admin_option_types_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/option_type.html.erb
+++ b/app/views/spree/admin/translations/option_type.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::OptionType.model_name.human), spree.admin_option_types_path, class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::OptionType.model_name.human), spree.admin_option_types_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/option_type.html.erb
+++ b/app/views/spree/admin/translations/option_type.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= I18n.t(:'spree.editing_resource', resource: Spree::OptionType.model_name.human) %> <span class="green">"<%= @option_type.name %>"</span>
+  <%= t(:'spree.editing_resource', resource: Spree::OptionType.model_name.human) %> <span class="green">"<%= @option_type.name %>"</span>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::OptionType.model_name.human), spree.admin_option_types_path, class: 'btn btn-primary' %>
+  <%= link_to t(:'spree.back_to_resource_list', resource: Spree::OptionType.model_name.human), spree.admin_option_types_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/option_value.html.erb
+++ b/app/views/spree/admin/translations/option_value.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= I18n.t(:'spree.editing_resource', resource: Spree::OptionValue.model_name.human) %> <span class="green">"<%= @option_value.name %>"</span>
+  <%= t(:'spree.editing_resource', resource: Spree::OptionValue.model_name.human) %> <span class="green">"<%= @option_value.name %>"</span>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::OptionValue.model_name.human), spree.edit_admin_option_type_path(@option_value.option_type), class: 'btn btn-primary' %>
+  <%= link_to t(:'spree.back_to_resource_list', resource: Spree::OptionValue.model_name.human), spree.edit_admin_option_type_path(@option_value.option_type), class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>

--- a/app/views/spree/admin/translations/option_value.html.erb
+++ b/app/views/spree/admin/translations/option_value.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::OptionValue.model_name.human) %> <span class="green">"<%= @option_value.name %>"</span>
+  <%= I18n.t(:'spree.editing_resource', resource: Spree::OptionValue.model_name.human) %> <span class="green">"<%= @option_value.name %>"</span>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::OptionValue.model_name.human), spree.edit_admin_option_type_path(@option_value.option_type), class: 'btn-primary' %>
+  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::OptionValue.model_name.human), spree.edit_admin_option_type_path(@option_value.option_type), class: 'btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>
@@ -16,9 +16,9 @@
     <%= form_for [:admin, :option_type, @resource] do |f| %>
       <%= render 'form_fields', f: f %>
       <div class="form-actions" data-hook="buttons">
-        <%= button Spree.t(:update), 'update' %>
-        <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t(:cancel), spree.edit_admin_option_type_path(@option_value.option_type) %>
+        <%= button I18n.t(:'spree.update'), 'update' %>
+        <span class="or"><%= I18n.t(:'spree.or') %></span>
+        <%= button_link_to I18n.t(:'spree.cancel'), spree.edit_admin_option_type_path(@option_value.option_type) %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/option_value.html.erb
+++ b/app/views/spree/admin/translations/option_value.html.erb
@@ -15,10 +15,10 @@
   <div class="col-md-8">
     <%= form_for [:admin, :option_type, @resource] do |f| %>
       <%= render 'form_fields', f: f %>
-      <div class="form-actions" data-hook="buttons">
-        <%= button I18n.t(:'spree.update'), 'update' %>
-        <span class="or"><%= I18n.t(:'spree.or') %></span>
-        <%= link_to I18n.t(:'spree.cancel'), spree.edit_admin_option_type_path(@option_value.option_type) %>
+
+      <div class="form-buttons filter-actions actions" data-hook="buttons">
+        <%= button_tag t('spree.actions.update'), class: 'btn btn-primary' %>
+        <%= link_to t('spree.actions.cancel'), spree.edit_admin_option_type_path(@option_value.option_type), class: 'button' %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/option_value.html.erb
+++ b/app/views/spree/admin/translations/option_value.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::OptionValue.model_name.human), spree.edit_admin_option_type_path(@option_value.option_type), class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::OptionValue.model_name.human), spree.edit_admin_option_type_path(@option_value.option_type), class: 'btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>
@@ -18,7 +18,7 @@
       <div class="form-actions" data-hook="buttons">
         <%= button Spree.t(:update), 'update' %>
         <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t(:cancel), spree.edit_admin_option_type_path(@option_value.option_type), icon: 'remove' %>
+        <%= button_link_to Spree.t(:cancel), spree.edit_admin_option_type_path(@option_value.option_type) %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/option_value.html.erb
+++ b/app/views/spree/admin/translations/option_value.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::OptionValue.model_name.human), spree.edit_admin_option_type_path(@option_value.option_type), class: 'btn-primary' %>
+  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::OptionValue.model_name.human), spree.edit_admin_option_type_path(@option_value.option_type), class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>
@@ -18,7 +18,7 @@
       <div class="form-actions" data-hook="buttons">
         <%= button I18n.t(:'spree.update'), 'update' %>
         <span class="or"><%= I18n.t(:'spree.or') %></span>
-        <%= button_link_to I18n.t(:'spree.cancel'), spree.edit_admin_option_type_path(@option_value.option_type) %>
+        <%= link_to I18n.t(:'spree.cancel'), spree.edit_admin_option_type_path(@option_value.option_type) %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/product.html.erb
+++ b/app/views/spree/admin/translations/product.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/product_tabs', current: 'Translations' %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Product.model_name.human), spree.admin_products_path, class: 'btn-primary' %>
+  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Product.model_name.human), spree.admin_products_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/product.html.erb
+++ b/app/views/spree/admin/translations/product.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/product_tabs', current: 'Translations' %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Product.model_name.human), spree.admin_products_path, class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Product.model_name.human), spree.admin_products_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/product.html.erb
+++ b/app/views/spree/admin/translations/product.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/product_tabs', current: 'Translations' %>
 
 <% content_for :page_actions do %>
-  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Product.model_name.human), spree.admin_products_path, class: 'btn btn-primary' %>
+  <%= link_to t(:'spree.back_to_resource_list', resource: Spree::Product.model_name.human), spree.admin_products_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/product.html.erb
+++ b/app/views/spree/admin/translations/product.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/product_tabs', current: 'Translations' %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Product.model_name.human), spree.admin_products_path, class: 'btn-primary' %>
+  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Product.model_name.human), spree.admin_products_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/product_property.html.erb
+++ b/app/views/spree/admin/translations/product_property.html.erb
@@ -15,10 +15,10 @@
   <div class="col-md-8">
     <%= form_for [:admin, @resource.product, @resource], method: :patch do |f| %>
       <%= render 'form_fields', f: f %>
-      <div class="form-actions" data-hook="buttons">
-        <%= button I18n.t(:'spree.update'), 'update' %>
-        <span class="or"><%= I18n.t(:'spree.or') %></span>
-        <%= link_to I18n.t(:'spree.cancel'), spree.admin_product_product_properties_path(@product_property.product) %>
+
+      <div class="form-buttons filter-actions actions" data-hook="buttons">
+        <%= button_tag t('spree.actions.update'), class: 'btn btn-primary' %>
+        <%= link_to t('spree.actions.cancel'), spree.admin_product_product_properties_path(@product_property.product), class: 'button' %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/product_property.html.erb
+++ b/app/views/spree/admin/translations/product_property.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::ProductProperty.model_name.human) %> <span class="green">"<%= @product_property.property.presentation %>"</span>
+  <%= I18n.t(:'spree.editing_resource', resource: Spree::ProductProperty.model_name.human) %> <span class="green">"<%= @product_property.property.presentation %>"</span>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::ProductProperty.model_name.human), spree.admin_product_product_properties_path(@product_property.product), class: 'btn-primary' %>
+  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::ProductProperty.model_name.human), spree.admin_product_product_properties_path(@product_property.product), class: 'btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>
@@ -16,9 +16,9 @@
     <%= form_for [:admin, @resource.product, @resource], method: :patch do |f| %>
       <%= render 'form_fields', f: f %>
       <div class="form-actions" data-hook="buttons">
-        <%= button Spree.t(:update), 'update' %>
-        <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t(:cancel), spree.admin_product_product_properties_path(@product_property.product) %>
+        <%= button I18n.t(:'spree.update'), 'update' %>
+        <span class="or"><%= I18n.t(:'spree.or') %></span>
+        <%= button_link_to I18n.t(:'spree.cancel'), spree.admin_product_product_properties_path(@product_property.product) %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/product_property.html.erb
+++ b/app/views/spree/admin/translations/product_property.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::ProductProperty.model_name.human), spree.admin_product_product_properties_path(@product_property.product), class: 'btn-primary', icon: 'icon-arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::ProductProperty.model_name.human), spree.admin_product_product_properties_path(@product_property.product), class: 'btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>
@@ -18,7 +18,7 @@
       <div class="form-actions" data-hook="buttons">
         <%= button Spree.t(:update), 'update' %>
         <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t(:cancel), spree.admin_product_product_properties_path(@product_property.product), icon: 'remove' %>
+        <%= button_link_to Spree.t(:cancel), spree.admin_product_product_properties_path(@product_property.product) %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/product_property.html.erb
+++ b/app/views/spree/admin/translations/product_property.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= I18n.t(:'spree.editing_resource', resource: Spree::ProductProperty.model_name.human) %> <span class="green">"<%= @product_property.property.presentation %>"</span>
+  <%= t(:'spree.editing_resource', resource: Spree::ProductProperty.model_name.human) %> <span class="green">"<%= @product_property.property.presentation %>"</span>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::ProductProperty.model_name.human), spree.admin_product_product_properties_path(@product_property.product), class: 'btn btn-primary' %>
+  <%= link_to t(:'spree.back_to_resource_list', resource: Spree::ProductProperty.model_name.human), spree.admin_product_product_properties_path(@product_property.product), class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>

--- a/app/views/spree/admin/translations/product_property.html.erb
+++ b/app/views/spree/admin/translations/product_property.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::ProductProperty.model_name.human), spree.admin_product_product_properties_path(@product_property.product), class: 'btn-primary' %>
+  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::ProductProperty.model_name.human), spree.admin_product_product_properties_path(@product_property.product), class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>
@@ -18,7 +18,7 @@
       <div class="form-actions" data-hook="buttons">
         <%= button I18n.t(:'spree.update'), 'update' %>
         <span class="or"><%= I18n.t(:'spree.or') %></span>
-        <%= button_link_to I18n.t(:'spree.cancel'), spree.admin_product_product_properties_path(@product_property.product) %>
+        <%= link_to I18n.t(:'spree.cancel'), spree.admin_product_product_properties_path(@product_property.product) %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/promotion.html.erb
+++ b/app/views/spree/admin/translations/promotion.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Promotion.model_name.human), spree.admin_promotions_path, class: 'btn-primary' %>
+  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Promotion.model_name.human), spree.admin_promotions_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/promotion.html.erb
+++ b/app/views/spree/admin/translations/promotion.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Promotion.model_name.human), spree.admin_promotions_path, class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Promotion.model_name.human), spree.admin_promotions_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/promotion.html.erb
+++ b/app/views/spree/admin/translations/promotion.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= I18n.t(:'spree.editing_resource', resource: Spree::Promotion.model_name.human) %>
+  <%= t(:'spree.editing_resource', resource: Spree::Promotion.model_name.human) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Promotion.model_name.human), spree.admin_promotions_path, class: 'btn btn-primary' %>
+  <%= link_to t(:'spree.back_to_resource_list', resource: Spree::Promotion.model_name.human), spree.admin_promotions_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/promotion.html.erb
+++ b/app/views/spree/admin/translations/promotion.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::Promotion.model_name.human) %>
+  <%= I18n.t(:'spree.editing_resource', resource: Spree::Promotion.model_name.human) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Promotion.model_name.human), spree.admin_promotions_path, class: 'btn-primary' %>
+  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Promotion.model_name.human), spree.admin_promotions_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/property.html.erb
+++ b/app/views/spree/admin/translations/property.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::Property.model_name.human) %>
+  <%= I18n.t(:'spree.editing_resource', resource: Spree::Property.model_name.human) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Property.model_name.human), spree.admin_properties_path, class: 'btn-primary' %>
+  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Property.model_name.human), spree.admin_properties_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/property.html.erb
+++ b/app/views/spree/admin/translations/property.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= I18n.t(:'spree.editing_resource', resource: Spree::Property.model_name.human) %>
+  <%= t(:'spree.editing_resource', resource: Spree::Property.model_name.human) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Property.model_name.human), spree.admin_properties_path, class: 'btn btn-primary' %>
+  <%= link_to t(:'spree.back_to_resource_list', resource: Spree::Property.model_name.human), spree.admin_properties_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/property.html.erb
+++ b/app/views/spree/admin/translations/property.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Property.model_name.human), spree.admin_properties_path, class: 'btn-primary' %>
+  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Property.model_name.human), spree.admin_properties_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/property.html.erb
+++ b/app/views/spree/admin/translations/property.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Property.model_name.human), spree.admin_properties_path, class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Property.model_name.human), spree.admin_properties_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/shipping_method.html.erb
+++ b/app/views/spree/admin/translations/shipping_method.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::ShippingMethod.model_name.human) %>
+  <%= I18n.t(:'spree.editing_resource', resource: Spree::ShippingMethod.model_name.human) %>
 <% end %>
 
 <% content_for :page_actions do %>
-    <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::ShippingMethod.model_name.human), spree.admin_shipping_methods_path, class: 'btn-primary' %>
+  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::ShippingMethod.model_name.human), spree.admin_shipping_methods_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/shipping_method.html.erb
+++ b/app/views/spree/admin/translations/shipping_method.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::ShippingMethod.model_name.human), spree.admin_shipping_methods_path, class: 'btn-primary' %>
+  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::ShippingMethod.model_name.human), spree.admin_shipping_methods_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/shipping_method.html.erb
+++ b/app/views/spree/admin/translations/shipping_method.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-    <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::ShippingMethod.model_name.human), spree.admin_shipping_methods_path, class: 'btn-primary', :icon => 'arrow-left' %>
+    <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::ShippingMethod.model_name.human), spree.admin_shipping_methods_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/shipping_method.html.erb
+++ b/app/views/spree/admin/translations/shipping_method.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= I18n.t(:'spree.editing_resource', resource: Spree::ShippingMethod.model_name.human) %>
+  <%= t(:'spree.editing_resource', resource: Spree::ShippingMethod.model_name.human) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::ShippingMethod.model_name.human), spree.admin_shipping_methods_path, class: 'btn btn-primary' %>
+  <%= link_to t(:'spree.back_to_resource_list', resource: Spree::ShippingMethod.model_name.human), spree.admin_shipping_methods_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/store.html.erb
+++ b/app/views/spree/admin/translations/store.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::Store.model_name.human) %>
+  <%= I18n.t(:'spree.editing_resource', resource: Spree::Store.model_name.human) %>
 <% end %>
 
 <%= render 'settings' %>
@@ -12,9 +12,9 @@
     <%= form_for [:admin, @resource], url: spree.admin_general_settings_path do |f| %>
       <%= render 'form_fields', f: f %>
       <div class="form-actions" data-hook="buttons">
-        <%= button Spree.t('actions.update'), 'refresh', 'submit', {class: 'btn-success'} %>
-        <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t('actions.cancel'), spree.edit_admin_general_settings_path %>
+        <%= button I18n.t(:'spree.actions.update'), 'refresh', 'submit', {class: 'btn-success'} %>
+        <span class="or"><%= I18n.t(:'spree.or') %></span>
+        <%= button_link_to I18n.t(:'spree.actions.cancel'), spree.edit_admin_general_settings_path %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/store.html.erb
+++ b/app/views/spree/admin/translations/store.html.erb
@@ -14,7 +14,7 @@
       <div class="form-actions" data-hook="buttons">
         <%= button Spree.t('actions.update'), 'refresh', 'submit', {class: 'btn-success'} %>
         <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t('actions.cancel'), spree.edit_admin_general_settings_path, icon: 'delete' %>
+        <%= button_link_to Spree.t('actions.cancel'), spree.edit_admin_general_settings_path %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/store.html.erb
+++ b/app/views/spree/admin/translations/store.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= I18n.t(:'spree.editing_resource', resource: Spree::Store.model_name.human) %>
+  <%= t(:'spree.editing_resource', resource: Spree::Store.model_name.human) %>
 <% end %>
 
 <%= render 'settings' %>

--- a/app/views/spree/admin/translations/store.html.erb
+++ b/app/views/spree/admin/translations/store.html.erb
@@ -14,7 +14,7 @@
       <div class="form-actions" data-hook="buttons">
         <%= button I18n.t(:'spree.actions.update'), 'refresh', 'submit', {class: 'btn-success'} %>
         <span class="or"><%= I18n.t(:'spree.or') %></span>
-        <%= button_link_to I18n.t(:'spree.actions.cancel'), spree.edit_admin_general_settings_path %>
+        <%= link_to I18n.t(:'spree.actions.cancel'), spree.edit_admin_general_settings_path %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/store.html.erb
+++ b/app/views/spree/admin/translations/store.html.erb
@@ -11,10 +11,10 @@
   <div class="col-md-8">
     <%= form_for [:admin, @resource], url: spree.admin_general_settings_path do |f| %>
       <%= render 'form_fields', f: f %>
-      <div class="form-actions" data-hook="buttons">
-        <%= button I18n.t(:'spree.actions.update'), 'refresh', 'submit', {class: 'btn-success'} %>
-        <span class="or"><%= I18n.t(:'spree.or') %></span>
-        <%= link_to I18n.t(:'spree.actions.cancel'), spree.edit_admin_general_settings_path %>
+
+      <div class="form-buttons filter-actions actions" data-hook="buttons">
+        <%= button_tag t('spree.actions.update'), class: 'btn btn-primary' %>
+        <%= link_to t('spree.actions.cancel'), spree.edit_admin_general_settings_path, class: 'button' %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/taxon.html.erb
+++ b/app/views/spree/admin/translations/taxon.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>
@@ -18,7 +18,7 @@
       <div class="form-actions" data-hook="buttons">
         <%= button Spree.t(:update), 'update' %>
         <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t(:cancel), spree.edit_admin_taxonomy_url(@taxon.taxonomy), icon: 'remove' %>
+        <%= button_link_to Spree.t(:cancel), spree.edit_admin_taxonomy_url(@taxon.taxonomy) %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/taxon.html.erb
+++ b/app/views/spree/admin/translations/taxon.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= I18n.t(:'spree.editing_resource', resource: Spree::Taxon.model_name.human) %>
+  <%= t(:'spree.editing_resource', resource: Spree::Taxon.model_name.human) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn btn-primary' %>
+  <%= link_to t(:'spree.back_to_resource_list', resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>

--- a/app/views/spree/admin/translations/taxon.html.erb
+++ b/app/views/spree/admin/translations/taxon.html.erb
@@ -15,10 +15,10 @@
   <div class="col-md-8">
     <%= form_for [:admin, @resource.taxonomy, @resource], url: spree.admin_taxonomy_taxon_path(@taxon.taxonomy, @taxon.id) do |f| %>
       <%= render 'form_fields', f: f %>
-      <div class="form-actions" data-hook="buttons">
-        <%= button I18n.t(:'spree.update'), 'update' %>
-        <span class="or"><%= I18n.t(:'spree.or') %></span>
-        <%= link_to I18n.t(:'spree.cancel'), spree.edit_admin_taxonomy_url(@taxon.taxonomy) %>
+
+      <div class="form-buttons filter-actions actions" data-hook="buttons">
+        <%= button_tag t('spree.actions.update'), class: 'btn btn-primary' %>
+        <%= link_to t('spree.actions.cancel'), spree.edit_admin_taxonomy_url(@taxon.taxonomy), class: 'button' %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/taxon.html.erb
+++ b/app/views/spree/admin/translations/taxon.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary' %>
+  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>
@@ -18,7 +18,7 @@
       <div class="form-actions" data-hook="buttons">
         <%= button I18n.t(:'spree.update'), 'update' %>
         <span class="or"><%= I18n.t(:'spree.or') %></span>
-        <%= button_link_to I18n.t(:'spree.cancel'), spree.edit_admin_taxonomy_url(@taxon.taxonomy) %>
+        <%= link_to I18n.t(:'spree.cancel'), spree.edit_admin_taxonomy_url(@taxon.taxonomy) %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/taxon.html.erb
+++ b/app/views/spree/admin/translations/taxon.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::Taxon.model_name.human) %>
+  <%= I18n.t(:'spree.editing_resource', resource: Spree::Taxon.model_name.human) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary' %>
+  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'settings' %>
@@ -16,9 +16,9 @@
     <%= form_for [:admin, @resource.taxonomy, @resource], url: spree.admin_taxonomy_taxon_path(@taxon.taxonomy, @taxon.id) do |f| %>
       <%= render 'form_fields', f: f %>
       <div class="form-actions" data-hook="buttons">
-        <%= button Spree.t(:update), 'update' %>
-        <span class="or"><%= Spree.t(:or) %></span>
-        <%= button_link_to Spree.t(:cancel), spree.edit_admin_taxonomy_url(@taxon.taxonomy) %>
+        <%= button I18n.t(:'spree.update'), 'update' %>
+        <span class="or"><%= I18n.t(:'spree.or') %></span>
+        <%= button_link_to I18n.t(:'spree.cancel'), spree.edit_admin_taxonomy_url(@taxon.taxonomy) %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/admin/translations/taxonomy.html.erb
+++ b/app/views/spree/admin/translations/taxonomy.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= I18n.t(:'spree.editing_resource', resource: Spree::Taxonomy.model_name.human) %>
+  <%= t(:'spree.editing_resource', resource: Spree::Taxonomy.model_name.human) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn btn-primary' %>
+  <%= link_to t(:'spree.back_to_resource_list', resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/taxonomy.html.erb
+++ b/app/views/spree/admin/translations/taxonomy.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_resource, resource: Spree::Taxonomy.model_name.human) %>
+  <%= I18n.t(:'spree.editing_resource', resource: Spree::Taxonomy.model_name.human) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary' %>
+  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/taxonomy.html.erb
+++ b/app/views/spree/admin/translations/taxonomy.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary', icon: 'arrow-left' %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/app/views/spree/admin/translations/taxonomy.html.erb
+++ b/app/views/spree/admin/translations/taxonomy.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn-primary' %>
+  <%= link_to I18n.t(:'spree.back_to_resource_list', resource: Spree::Taxonomy.model_name.human), spree.admin_taxonomies_path, class: 'btn btn-primary' %>
 <% end %>
 
 <%= render 'form' %>

--- a/spec/features/admin/translations_spec.rb
+++ b/spec/features/admin/translations_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Translations", :js do
   stub_authorization!
   include_context 'with pt-BR locale file in place'
 
-  let(:language) { Spree.t(:this_file_language, scope: 'i18n', locale: 'pt-BR') }
+  let(:language) { I18n.t(:this_file_language, scope: 'spree.i18n', locale: 'pt-BR') }
   let!(:store) { create(:store, available_locales: available_locales) }
   let(:available_locales) { [:en, :'pt-BR'] }
 
@@ -225,8 +225,8 @@ RSpec.describe "Translations", :js do
   context "store" do
     pending 'saves translated attributes properly' do
       visit spree.edit_admin_general_settings_path
-      click_link Spree.t(:configurations)
-      click_link Spree.t(:'globalize.store_translations')
+      click_link I18n.t(:configurations)
+      click_link I18n.t(:'spree.globalize.store_translations')
 
       within("#attr_fields .name.pt-BR") { fill_in_name "nome store" }
       click_on "Update"
@@ -267,7 +267,7 @@ RSpec.describe "Translations", :js do
   end
 
   context "localization settings" do
-    let(:language) { Spree.t(:this_file_language, scope: 'i18n', locale: 'pt-BR') }
+    let(:language) { I18n.t(:this_file_language, scope: 'spree.i18n', locale: 'pt-BR') }
 
     before do
       create(:store, available_locales: [:en])
@@ -283,7 +283,7 @@ RSpec.describe "Translations", :js do
   end
 
   context "permalink routing" do
-    let(:language) { Spree.t(:this_file_language, scope: 'i18n', locale: 'pt-BR') }
+    let(:language) { I18n.t(:this_file_language, scope: 'spree.i18n', locale: 'pt-BR') }
     let(:product) { create(:product) }
     let(:available_locales) { [:en, :'pt-BR'] }
 

--- a/spec/features/admin/translations_spec.rb
+++ b/spec/features/admin/translations_spec.rb
@@ -10,8 +10,11 @@ RSpec.describe "Translations", :js do
 
   before do
     create(:store, available_locales: available_locales)
-    reset_spree_preferences
     SolidusGlobalize::Config.supported_locales = [:en, :'pt-BR']
+  end
+
+  after do
+    SolidusGlobalize::Config.supported_locales = [:en]
   end
 
   context "products" do

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -2,9 +2,6 @@
 
 RSpec.describe "Translations" do
   include_context 'with pt-BR locale file in place'
-  before do
-    SolidusGlobalize::Config.supported_locales = [:en, :'pt-BR']
-  end
 
   context 'product' do
     let!(:product) do
@@ -18,8 +15,14 @@ RSpec.describe "Translations" do
         ])
     end
 
-    before do
+    around do |example|
       I18n.locale = 'pt-BR'
+      SolidusGlobalize::Config.supported_locales = [:en, :'pt-BR']
+
+      example.run
+
+      I18n.locale = 'en'
+      SolidusGlobalize::Config.supported_locales = [:en]
     end
 
     it 'displays translated product page' do

--- a/spec/models/product_property_spec.rb
+++ b/spec/models/product_property_spec.rb
@@ -11,7 +11,7 @@ module Spree
       end
 
       it 'still validates the "value" field without raising an exception' do
-        expect { subject.valid? }.not_to raise_error(NoMethodError)
+        expect { subject.valid? }.not_to raise_error
       end
     end
   end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -58,8 +58,18 @@ module Spree
 
     context "when soft-deleting" do
       subject(:soft_deleting) do
-        product.destroy
+        product.discard
         product.reload
+      end
+
+      it 'keeps the core discard callbacks' do
+        expect(product.variants_including_master.kept.size).to eq 1
+        expect(product.variants_including_master.with_deleted.size).to eq 1
+
+        soft_deleting
+
+        expect(product.variants_including_master.kept.size).to eq 0
+        expect(product.variants_including_master.with_deleted.size).to eq 1
       end
 
       it "keeps the translation on deletion" do

--- a/spec/models/shipping_method_spec.rb
+++ b/spec/models/shipping_method_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Spree
+  RSpec.describe ShippingMethod, type: :model do
+    let(:shipping_method) { create(:shipping_method) }
+
+    context "when soft-deleting" do
+      subject(:soft_deleting) do
+        shipping_method.discard
+        shipping_method.reload
+      end
+
+      it "keeps the translation on deletion" do
+        soft_deleting
+        expect(shipping_method.translations).not_to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR removes all the deprecation warning currently present when running specs against solidus master. There's a commit for each warning, so it will be easier to read and review.