### PR TITLE
Soft deletion of shipping method translations

### DIFF
--- a/app/decorators/models/solidus_globalize/spree/shipping_method_decorator.rb
+++ b/app/decorators/models/solidus_globalize/spree/shipping_method_decorator.rb
@@ -7,6 +7,28 @@ module SolidusGlobalize
         base.class_eval do
           translates :name, fallbacks_for_empty_translations: true
           include SolidusGlobalize::Translatable
+
+          after_discard do
+            # Discard associated records
+            translations.discard_all
+          end
+
+          translation_class.class_eval do
+            # Paranoia soft delete
+            acts_as_paranoid
+
+            # Warn users of future Paranoia gem removal
+            include ::Spree::ParanoiaDeprecations
+
+            # Account for Paranoia migration
+            include Discard::Model
+            self.discard_column = :deleted_at
+
+            # Paranoid sets the default scope and Globalize rewrites all query methods.
+            # Therefore we prefer to unset the default_scopes over injecting 'unscope'
+            # in every Globalize query method.
+            self.default_scopes = []
+          end
         end
       end
 

--- a/db/migrate/20210115125441_add_deleted_at_to_shipping_method_translations.rb
+++ b/db/migrate/20210115125441_add_deleted_at_to_shipping_method_translations.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToShippingMethodTranslations < ActiveRecord::Migration[6.1]
+  def change
+    unless column_exists?(:spree_shipping_method_translations, :deleted_at)
+      add_column :spree_shipping_method_translations, :deleted_at, :datetime
+      add_index :spree_shipping_method_translations, :deleted_at
+    end
+  end
+end

--- a/spec/models/shipping_method_spec.rb
+++ b/spec/models/shipping_method_spec.rb
@@ -14,6 +14,11 @@ module Spree
         soft_deleting
         expect(shipping_method.translations).not_to be_empty
       end
+
+      it "deleted_at set on reload" do
+        soft_deleting
+        expect(shipping_method.translations.first.deleted_at).not_to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
- Datetime column `deleted_at` added to shipping_method_translations table
- Methods for shipping_method discard and discard of associated translations
- Spec to test whether translation record has a value set to deleted_at on reload