### PR TITLE
feat: upgrade globalize to support Rails 6.1

### DIFF
--- a/solidus_globalize.gemspec
+++ b/solidus_globalize.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'deface', '~> 1.5'
   s.add_dependency 'friendly_id-globalize'
-  s.add_dependency 'globalize', '~> 5.1'
+  s.add_dependency 'globalize', '~> 6.0'
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
   s.add_dependency 'solidus_support', '~> 0.5'
 


### PR DESCRIPTION
To use Rails 6.1, globalize needs version 6.0