### PR TITLE
Update gemspec to allow Ruby 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Add the following to your `Gemfile`:
 gem 'solidus_globalize', github: 'solidusio-contrib/solidus_globalize'
 ```
 
+For Ruby 3.x you have to force the usage of the friendly_id-globalize master version:
+
+```ruby
+gem 'friendly_id-globalize', github: 'norman/friendly_id-globalize', branch: "master"
+gem 'solidus_globalize', github: 'solidusio-contrib/solidus_globalize'
+```
+
+
 Run `bundle install`
 
 You can use the generator to install migrations and append solidus_globalize assets to

--- a/solidus_globalize.gemspec
+++ b/solidus_globalize.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     s.metadata["source_code_uri"] = 'https://github.com/solidusio-contrib/solidus_globalize'
   end
 
-  s.required_ruby_version = '~> 2.4'
+  s.required_ruby_version = ['>= 2.4', '< 4.0']
 
   s.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
Works with ruby 3.x if friendly_id-globalize master version with this fix
https://github.com/norman/friendly_id-globalize/commit/097eed19e9d2f6bbf5ee7636493c03f7025d813b
is used. Describe this for now in the README