### PR TITLE
Fix product name search retention

### DIFF
--- a/app/overrides/spree/admin/products/index/replace_name_field_with_translations_name.html.erb.deface
+++ b/app/overrides/spree/admin/products/index/replace_name_field_with_translations_name.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- replace_contents '[data-hook="admin_products_index_search"] > div:first-child .field' -->
+<%= f.label :translations_name_cont, Spree::Product.human_attribute_name(:name) %>
+<%= f.text_field :translations_name_cont, size: 15 %>


### PR DESCRIPTION
The override allows the product name search term to be retained after search results are shown. This was not working because the search param is for the product translations and did not match the field name.