### PR TITLE
Upgrade globalize to version 7.0 for Rails 7.2 support

### DIFF
--- a/solidus_globalize.gemspec
+++ b/solidus_globalize.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'deface', '~> 1.5'
   s.add_dependency 'friendly_id-globalize'
-  s.add_dependency 'globalize', '~> 6.0'
+  s.add_dependency 'globalize', '~> 7.0'
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
   s.add_dependency 'solidus_support', '~> 0.8'
 


### PR DESCRIPTION
This PR updates the globalize dependency to ~> 7.0 to support Rails 7.2.
https://github.com/globalize/globalize/releases/tag/v7.0.0